### PR TITLE
ci: fuzz and new fork number

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,8 @@ jobs:
         env:
           ALCHEMY_API_URI: ${{ secrets.ALCHEMY_API_URI }}
         run: >
-          FOUNDRY_FUZZ_RUNS=4096 forge test
-            -vvv
-            --force
-            --fork-url "$ALCHEMY_API_URI"
+          FOUNDRY_FUZZ_RUNS=4096 forge test \
+            -vvv \
+            --force \
+            --fork-url "$ALCHEMY_API_URI" \
             --fork-block-number 14167146


### PR DESCRIPTION
* arbitrarily chose 4096 as the amount of fuzz runs
* arbirarily chose new fork number - cycle 181 is the latest claimable cycle