### PR TITLE
feat: mint fees as shares to the maintainer

### DIFF
--- a/src/Recycler.sol
+++ b/src/Recycler.sol
@@ -601,7 +601,7 @@ contract Recycler is IRecycler, Lock, Auth, Pause {
             uint256 fees = (amount * fee) / MAX_FEE;
             uint256 shares;
 
-            if (totalShares == 0 || totalSupply() + amount - fees == 0) {
+            if (totalShares == 0 || totalSupply() - fees == 0) {
                 shares = fees;
             } else {
                 shares = shares = (fees * totalShares) / (totalSupply() - fees);


### PR DESCRIPTION
* moves the fee logic from claim to stake.
  this is because we're denominated in tTOKE, not TOKE, and having
  the logic in stake then simplifies it.